### PR TITLE
update module name

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
-  "name": "alertlogic-agents",
-  "version": "0.1.0",
+  "name": "alertlogic-al_agents",
+  "version": "0.2.0",
   "author": "alertlogic",
   "summary": "Alert Logic Agent Puppet Module",
   "license": "Apache-2.0",
@@ -71,7 +71,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=3.7.2 <4.0.0"
+      "version_requirement": ">=3.7.2 <4.9.0"
     }
   ]
 }


### PR DESCRIPTION
module name in puppet forge metadata previously called agents
while the actual module class name is al_agents