### PR TITLE
syslog related class fix to template path, facter and duplicate declaration

### DIFF
--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -1,14 +1,18 @@
 class al_agents::linux inherits al_agents {
 
-  if $al_agents::syslogng_detected {
+  if $syslog_type == 'none' {
+    info("no syslog detected skipping syslog configuration for AL Agent")
+  }
+
+  if $syslog_type == 'syslog-ng' {
     class { '::al_agents::syslogng': }
   }
 
-  if $al_agents::rsyslog_detected {
+  if $syslog_type == 'rsyslog' {
     class { '::al_agents::rsyslog': }
   }
 
-  if $al_agents::for_imaging == false {
+  if $al_agents::for_imaging == 'false' {
     anchor { 'al_agents::linux::begin': } ->
     class { '::al_agents::install': } ->
     class { '::al_agents::configure': } ->

--- a/manifests/rsyslog.pp
+++ b/manifests/rsyslog.pp
@@ -1,15 +1,13 @@
 class al_agents::rsyslog inherits al_agents {
-
-  include 'rsyslog'
-
-  service { 'rsyslog':
-    ensure  => 'running',
-    enable  => true,
-    require => Package['rsyslog'],
+  if ! defined(Package['rsyslog']) {
+    service { 'rsyslog':
+      ensure  => 'running',
+      enable  => true,
+    }
   }
 
   file { '/etc/rsyslog.d/alertlogic.conf':
-    content => template('rsyslog/alertlogic.conf.erb'),
+    content => template('al_agents/rsyslog/alertlogic.conf.erb'),
     notify  => Service['rsyslog'],
     owner   => root,
     group   => root,

--- a/manifests/syslogng.pp
+++ b/manifests/syslogng.pp
@@ -1,29 +1,23 @@
 class al_agents::syslogng inherits al_agents {
 
-  service { 'syslog-ng':
-    ensure  => 'running',
-    enable  => true,
-    require => Package['syslog-ng'],
-  }
-
-  file { '/etc/syslog-ng/conf.d':
-    ensure => 'directory',
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755'
-  }
-
-  if syslog_ng_pre33() {
+  if versioncmp( $syslog_ng_ver, '3.2') <= 0 {
     file_line { 'append_alertlogic_conf_to_syslog_ng':
       path => '/etc/syslog-ng/syslog-ng.conf',
       line => "include '/etc/syslog-ng/conf.d/alertlogic.conf';",
     }
   }
-  
+
   $source_log = $al_agents::source_log
 
+  if ! defined(Package['syslog-ng']) {
+    service { 'syslog-ng':
+      ensure  => 'running',
+      enable  => true,
+    }
+  }
+
   file { '/etc/syslog-ng/conf.d/alertlogic.conf':
-    content => template('syslog_ng/alertlogic.conf.erb'),
+    content => template('al_agents/syslog_ng/alertlogic.conf.erb'),
     notify  => Service['syslog-ng'],
     owner   => root,
     group   => root,


### PR DESCRIPTION
Update relevant class to use facter to check syslog type and version
Check for duplicate declaration of resource like Service or Packages
Update the templates directory path to include /al_agents